### PR TITLE
Preserve newlines and comments

### DIFF
--- a/pkg/rewrite/write/docker.go
+++ b/pkg/rewrite/write/docker.go
@@ -115,8 +115,10 @@ func (d *DockerfileWriter) writeFile(
 
 	const maxNumFields = 3
 
-	var outputBuffer bytes.Buffer
-	var lastEndLine int = 0
+	var (
+		outputBuffer bytes.Buffer
+		lastEndLine  int
+	)
 
 	for _, child := range loadedDockerfile.AST.Children {
 		outputLine := child.Original
@@ -164,13 +166,16 @@ func (d *DockerfileWriter) writeFile(
 
 		expectedLineNo := lastEndLine + len(child.PrevComment) + 1
 		if expectedLineNo != child.StartLine {
-			outputBuffer.WriteString(strings.Repeat("\n", child.StartLine-expectedLineNo))
+			newlines := strings.Repeat("\n", child.StartLine-expectedLineNo)
+			outputBuffer.WriteString(newlines)
 		}
+
 		lastEndLine = child.EndLine
 
 		for _, comment := range child.PrevComment {
 			fmt.Fprintf(&outputBuffer, "# %s\n", comment)
 		}
+
 		outputBuffer.WriteString(fmt.Sprintf("%s\n", outputLine))
 	}
 

--- a/pkg/rewrite/write/docker.go
+++ b/pkg/rewrite/write/docker.go
@@ -116,6 +116,7 @@ func (d *DockerfileWriter) writeFile(
 	const maxNumFields = 3
 
 	var outputBuffer bytes.Buffer
+	var lastEndLine int = 0
 
 	for _, child := range loadedDockerfile.AST.Children {
 		outputLine := child.Original
@@ -161,6 +162,15 @@ func (d *DockerfileWriter) writeFile(
 			outputLine = d.formatASTLine(child, raw)
 		}
 
+		expectedLineNo := lastEndLine + len(child.PrevComment) + 1
+		if expectedLineNo != child.StartLine {
+			outputBuffer.WriteString(strings.Repeat("\n", child.StartLine-expectedLineNo))
+		}
+		lastEndLine = child.EndLine
+
+		for _, comment := range child.PrevComment {
+			fmt.Fprintf(&outputBuffer, "# %s\n", comment)
+		}
 		outputBuffer.WriteString(fmt.Sprintf("%s\n", outputLine))
 	}
 

--- a/pkg/rewrite/write/docker_test.go
+++ b/pkg/rewrite/write/docker_test.go
@@ -27,7 +27,6 @@ func TestDockerfileWriter(t *testing.T) {
 				[]byte(`FROM busybox
 COPY . .
 FROM redis:latest
-# comment
 FROM golang:latest@sha256:12345
 `),
 			},
@@ -61,6 +60,46 @@ FROM golang:latest@sha256:12345
 COPY . .
 FROM redis:latest@sha256:redis
 FROM golang:latest@sha256:golang
+`),
+			},
+		},
+		{
+			Name: "Comments and newlines",
+			Contents: [][]byte{
+				[]byte(`FROM busybox
+
+
+COPY . .
+# my comment
+RUN echo
+
+# cannot distinguish where newlines are
+
+RUN touch foo
+`),
+			},
+			PathImages: map[string][]*parse.DockerfileImage{
+				"Dockerfile": {
+					{
+						Image: &parse.Image{
+							Name:   "busybox",
+							Tag:    "latest",
+							Digest: "busybox",
+						},
+					},
+				},
+			},
+			Expected: [][]byte{
+				[]byte(`FROM busybox:latest@sha256:busybox
+
+
+COPY . .
+# my comment
+RUN echo
+
+
+# cannot distinguish where newlines are
+RUN touch foo
 `),
 			},
 		},


### PR DESCRIPTION
As noted in #63, the rewriter should preserve newlines and comments. There is just one hiccup: the parser does not preserve the newlines exactly, these two Dockerfiles seem identical:

```
FROM scratch

# something
RUN foo
```
and 
```
FROM scratch
# something

RUN foo
```

So I decided to to make comments sticky to the next command after them - so in this case both of these would be rewritten to the way the first one is laid out. This also ensures that RUN and all remaining command are on the same line as before.

There are other things I could not control, e.g. `#foo ` is turned into `# foo` etc., because I don't have whitespace info in the parser.