### PR TITLE
default to current dir for rewrite temp paths

### DIFF
--- a/cmd/rewrite/rewrite.go
+++ b/cmd/rewrite/rewrite.go
@@ -44,7 +44,7 @@ func NewRewriteCmd() (*cobra.Command, error) {
 			}
 			defer reader.Close()
 
-			err = rewriter.RewriteLockfile(reader)
+			err = rewriter.RewriteLockfile(reader, flags.TempDir)
 			if err == nil {
 				fmt.Println(
 					"successfully rewrote files referenced by lockfile!",
@@ -58,7 +58,7 @@ func NewRewriteCmd() (*cobra.Command, error) {
 		"lockfile-name", "docker-lock.json", "Lockfile to read from",
 	)
 	rewriteCmd.Flags().String(
-		"tempdir", "",
+		"tempdir", ".",
 		"Directory where a temporary directory will be created/deleted "+
 			"during a rewrite transaction",
 	)
@@ -85,20 +85,16 @@ func SetupRewriter(flags *Flags) (rewrite.IRewriter, error) {
 		return nil, err
 	}
 
-	dockerfileWriter := write.NewDockerfileWriter(
-		flags.ExcludeTags, flags.TempDir,
-	)
+	dockerfileWriter := write.NewDockerfileWriter(flags.ExcludeTags)
 
 	composefileWriter, err := write.NewComposefileWriter(
-		dockerfileWriter, flags.ExcludeTags, flags.TempDir,
+		dockerfileWriter, flags.ExcludeTags,
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	kubernetesfileWriter := write.NewKubernetesfileWriter(
-		flags.ExcludeTags, flags.TempDir,
-	)
+	kubernetesfileWriter := write.NewKubernetesfileWriter(flags.ExcludeTags)
 
 	writer, err := rewrite.NewWriter(
 		dockerfileWriter, composefileWriter, kubernetesfileWriter,

--- a/pkg/rewrite/rewriter_test.go
+++ b/pkg/rewrite/rewriter_test.go
@@ -477,7 +477,7 @@ services:
 			}
 			reader := bytes.NewReader(lockfileByt)
 
-			err = rewriter.RewriteLockfile(reader)
+			err = rewriter.RewriteLockfile(reader, tempDir)
 
 			if test.ShouldFail {
 				if err == nil {

--- a/pkg/rewrite/types.go
+++ b/pkg/rewrite/types.go
@@ -22,6 +22,7 @@ type IPreprocessor interface {
 type IWriter interface {
 	WriteFiles(
 		lockfile map[kind.Kind]map[string][]interface{},
+		tempDir string,
 		done <-chan struct{},
 	) <-chan write.IWrittenPath
 }
@@ -29,7 +30,7 @@ type IWriter interface {
 // IRewriter provides an interface for Rewriters, which are responsible for
 // rewriting files referenced in a Lockfile with images from the Lockfile.
 type IRewriter interface {
-	RewriteLockfile(lockfileReader io.Reader) error
+	RewriteLockfile(lockfileReader io.Reader, tempDir string) error
 }
 
 // IRenamer provides an interface for Renamers, which rename temporary files

--- a/pkg/rewrite/write/compose_test.go
+++ b/pkg/rewrite/write/compose_test.go
@@ -690,12 +690,10 @@ services:
 				t, tempDir, pathsToWrite, test.Contents,
 			)
 
-			dockerfileWriter := write.NewDockerfileWriter(
-				test.ExcludeTags, tempDir,
-			)
+			dockerfileWriter := write.NewDockerfileWriter(test.ExcludeTags)
 
 			composefileWriter, err := write.NewComposefileWriter(
-				dockerfileWriter, test.ExcludeTags, tempDir,
+				dockerfileWriter, test.ExcludeTags,
 			)
 			if err != nil {
 				t.Fatal(err)
@@ -705,7 +703,7 @@ services:
 			defer close(done)
 
 			writtenPathResults := composefileWriter.WriteFiles(
-				tempPathImages, done,
+				tempPathImages, tempDir, done,
 			)
 
 			var got []string

--- a/pkg/rewrite/write/docker_test.go
+++ b/pkg/rewrite/write/docker_test.go
@@ -412,13 +412,13 @@ FROM redis
 				t, tempDir, pathsToWrite, test.Contents,
 			)
 
-			writer := write.NewDockerfileWriter(test.ExcludeTags, tempDir)
+			writer := write.NewDockerfileWriter(test.ExcludeTags)
 
 			done := make(chan struct{})
 			defer close(done)
 
 			writtenPathResults := writer.WriteFiles(
-				tempPathImages, done,
+				tempPathImages, tempDir, done,
 			)
 
 			var got []string

--- a/pkg/rewrite/write/kubernetes_test.go
+++ b/pkg/rewrite/write/kubernetes_test.go
@@ -624,13 +624,13 @@ spec:
 				t, tempDir, pathsToWrite, test.Contents,
 			)
 
-			writer := write.NewKubernetesfileWriter(test.ExcludeTags, tempDir)
+			writer := write.NewKubernetesfileWriter(test.ExcludeTags)
 
 			done := make(chan struct{})
 			defer close(done)
 
 			writtenPathResults := writer.WriteFiles(
-				tempPathImages, done,
+				tempPathImages, tempDir, done,
 			)
 
 			var got []string

--- a/pkg/rewrite/write/types.go
+++ b/pkg/rewrite/write/types.go
@@ -4,11 +4,12 @@ package write
 import "github.com/safe-waters/docker-lock/pkg/kind"
 
 // IWriter provides an interface for Writers, which are responsible for
-// writing files with information from a Lockfile to temporary paths.
+// writing files with information from a Lockfile to paths in outputDir.
 type IWriter interface {
 	Kind() kind.Kind
 	WriteFiles(
 		pathImages map[string][]interface{},
+		outputDir string,
 		done <-chan struct{},
 	) <-chan IWrittenPath
 }

--- a/pkg/rewrite/writer.go
+++ b/pkg/rewrite/writer.go
@@ -35,6 +35,7 @@ func NewWriter(writers ...write.IWriter) (IWriter, error) {
 // WriteFiles writes files with images from a Lockfile.
 func (w *writer) WriteFiles(
 	lockfile map[kind.Kind]map[string][]interface{},
+	tempDir string,
 	done <-chan struct{},
 ) <-chan write.IWrittenPath {
 	if lockfile == nil {
@@ -61,7 +62,7 @@ func (w *writer) WriteFiles(
 				defer waitGroup.Done()
 
 				for writtenPath := range writer.WriteFiles(
-					lockfile[kind], done,
+					lockfile[kind], tempDir, done,
 				) {
 					select {
 					case <-done:

--- a/pkg/rewrite/writer_test.go
+++ b/pkg/rewrite/writer_test.go
@@ -170,16 +170,14 @@ spec:
 				t, tempDir, pathsToWrite, test.Contents,
 			)
 
-			dockerfileWriter := write.NewDockerfileWriter(false, tempDir)
+			dockerfileWriter := write.NewDockerfileWriter(false)
 			composefileWriter, err := write.NewComposefileWriter(
-				dockerfileWriter, false, tempDir,
+				dockerfileWriter, false,
 			)
 			if err != nil {
 				t.Fatal(err)
 			}
-			kubernetesfileWriter := write.NewKubernetesfileWriter(
-				false, tempDir,
-			)
+			kubernetesfileWriter := write.NewKubernetesfileWriter(false)
 
 			writer, err := rewrite.NewWriter(
 				dockerfileWriter, composefileWriter, kubernetesfileWriter,
@@ -191,7 +189,9 @@ spec:
 			done := make(chan struct{})
 			defer close(done)
 
-			writtenPathResults := writer.WriteFiles(lockfileWithTempDir, done)
+			writtenPathResults := writer.WriteFiles(
+				lockfileWithTempDir, tempDir, done,
+			)
 
 			var got []string
 

--- a/test/demo-app/tests.sh
+++ b/test/demo-app/tests.sh
@@ -104,7 +104,7 @@ function run_rewrite_verify_tests() {
     echo "------ RUNNING REWRITE/VERIFY TESTS ------"
 
     echo "default"
-    docker lock rewrite --tempdir .
+    docker lock rewrite
     docker lock verify
     diff_files docker-compose.yml docker-compose-rewrite.yml
     diff_files web/Dockerfile web/Dockerfile-rewrite
@@ -112,7 +112,7 @@ function run_rewrite_verify_tests() {
     diff_files pod.yml pod-rewrite.yml
 
     echo "--exclude-tags"
-    docker lock rewrite --tempdir . --exclude-tags
+    docker lock rewrite --exclude-tags
     docker lock verify --exclude-tags
     diff_files docker-compose.yml docker-compose-rewrite-exclude-tags.yml
     diff_files web/Dockerfile web/Dockerfile-rewrite-exclude-tags


### PR DESCRIPTION
* Previously, defaulted to using the default temporary directory when rewriting, which would cause problems if that directory was on a separate drive from the current directory.
* Now, all paths are temporarily rewritten to `./temp-rewrite`, unless otherwise specified via `--temp-dir` flag. This fixes #82  by making the default behavior more friendly.