### PR TITLE
log the path of images that cannot update

### DIFF
--- a/pkg/generate/update/digest.go
+++ b/pkg/generate/update/digest.go
@@ -18,11 +18,11 @@ func NewDigestRequester() IDigestRequester {
 // Digest queries a registry for a sha256 digest given a name and tag.
 func (d *digestRequester) Digest(name string, tag string) (string, error) {
 	if name == "" {
-		return "", errors.New("'name' cannot be empty")
+		return "", errors.New("image 'name' cannot be empty")
 	}
 
 	if tag == "" {
-		return "", errors.New("'tag' cannot be empty")
+		return "", errors.New("image 'tag' cannot be empty")
 	}
 
 	nameTag := fmt.Sprintf("%s:%s", name, tag)

--- a/pkg/generate/update/updater.go
+++ b/pkg/generate/update/updater.go
@@ -2,6 +2,7 @@ package update
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"reflect"
 	"sync"
@@ -105,10 +106,19 @@ func (i *imageDigestUpdater) UpdateDigests(
 					image.Name(), image.Tag(),
 				)
 				if err != nil && !i.ignoreMissingDigests {
+					errMsg := fmt.Errorf(
+						"failed to update image with err: %v", err,
+					)
+
+					metadata := image.Metadata()
+					if path, ok := metadata["path"]; ok {
+						errMsg = fmt.Errorf("on '%s': %v", path, errMsg)
+					}
+
 					select {
 					case <-done:
 					case updatedImages <- parse.NewImage(
-						image.Kind(), "", "", "", nil, err,
+						image.Kind(), "", "", "", nil, errMsg,
 					):
 					}
 


### PR DESCRIPTION
Errors with the path when an image fails to update, as mentioned in #89 