### PR TITLE
add compose.yml and compose.yaml to default files

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,9 +179,10 @@ $ docker lock version --help
 ## Generate
 ### Commands for Dockerfiles, docker-compose files, and Kubernetes manifests
 * `docker lock generate` will collect all default files (`Dockerfile`,
-`docker-compose.yaml`, `docker-compose.yml`, `pod.yml`, `pod.yaml`,
-`deployment.yml`, `deployment.yaml`, `job.yml`, and `job.yaml` in the default
-base directory, the directory from which the command is run) and generate a Lockfile.
+`compose.yml`, `compose.yaml`, `docker-compose.yaml`, `docker-compose.yml`,
+`pod.yml`, `pod.yaml`, `deployment.yml`, `deployment.yaml`, `job.yml`,
+and `job.yaml` in the default base directory, the directory from which
+the command is run) and generate a Lockfile.
 
 * `docker lock generate --lockfile-name=[file name]` will generate a Lockfile with the
 file name as the output, instead of the default `docker-lock.json`.
@@ -226,9 +227,10 @@ Dockerfiles files and Kubernetes manifests and generate a Lockfile.
 excluding all docker-compose files.
 
 * `docker lock generate --composefile-recursive` will collect all default
-docker-compose files (`docker-compose.yaml`, `docker-compose.yml`) in
-subdirectories from the base directory as well as default Dockerfiles
-and Kubernetes manifests in the base directory and generate a Lockfile.
+docker-compose files (`compose.yml`, `compose.yaml`,
+`docker-compose.yaml`, `docker-compose.yml`) in subdirectories from the
+base directory as well as default Dockerfiles and Kubernetes manifests in
+the base directory and generate a Lockfile.
 
 * `docker lock generate --composefile-globs='[glob pattern]'` will collect all
 docker-compose files that match the glob pattern relative to the base directory as well

--- a/cmd/generate/defaults.go
+++ b/cmd/generate/defaults.go
@@ -3,6 +3,7 @@ package generate
 import (
 	"errors"
 
+	"github.com/compose-spec/compose-go/cli"
 	"github.com/safe-waters/docker-lock/pkg/generate"
 	"github.com/safe-waters/docker-lock/pkg/generate/collect"
 	"github.com/safe-waters/docker-lock/pkg/generate/format"
@@ -15,7 +16,8 @@ import (
 // Composefiles, and Kubernetesfiles.
 //
 // For all three, respectively, the defaults are
-// ["Dockerfile"], ["docker-compose.yml", "docker-compose.yaml"], and
+// ["Dockerfile"], ["compose.yml", "compose.yaml",
+// "docker-compose.yml", "docker-compose.yaml"], and
 // ["deployment.yml", "deployment.yaml", "pod.yml", "pod.yaml",
 // "job.yml", "job.yaml"].
 //
@@ -56,7 +58,7 @@ func DefaultPathCollector(flags *Flags) (generate.IPathCollector, error) {
 		composefileCollector, err = collect.NewPathCollector(
 			kind.Composefile,
 			flags.FlagsWithSharedValues.BaseDir,
-			[]string{"docker-compose.yml", "docker-compose.yaml"},
+			cli.DefaultFileNames,
 			flags.ComposefileFlags.ManualPaths, flags.ComposefileFlags.Globs,
 			flags.ComposefileFlags.Recursive,
 		)

--- a/docker-lock.json
+++ b/docker-lock.json
@@ -4,7 +4,7 @@
 			{
 				"name": "ubuntu",
 				"tag": "bionic",
-				"digest": "139b3846cee2e63de9ced83cee7023a2d95763ee2573e5b0ab6dea9dfbd4db8f"
+				"digest": "3b8692dc4474d4f6043fae285676699361792ce1828e22b1b57367b5c05457e3"
 			}
 		],
 		"Dockerfile.alpine": [


### PR DESCRIPTION
According to the [new compose spec](https://github.com/compose-spec/compose-spec/blob/master/spec.md#compose-file) (and the docker compose command), `compose.yaml` and `compose.yml` are the new, preferred forms of `docker-compose.yaml` and `docker-compose.yml`. All are supported for backwards compatibility.